### PR TITLE
Bump library versions

### DIFF
--- a/card_verify_android_integration.md
+++ b/card_verify_android_integration.md
@@ -36,8 +36,8 @@ build.gradle file:
 
 ```gradle
 dependencies {
-    implementation 'com.getbouncer:cardscan-base:1.0.5113'
-    implementation 'com.getbouncer:cardverify:1.0.5113'
+    implementation 'com.getbouncer:cardscan-base:1.0.5114'
+    implementation 'com.getbouncer:cardverify:1.0.5114'
 }
 ```
 


### PR DESCRIPTION
bump versions to align with https://github.com/getbouncer/cardscan-android/pull/59